### PR TITLE
Make it work with both versions of Bananapi M4 zero

### DIFF
--- a/source/bananapi.c
+++ b/source/bananapi.c
@@ -870,7 +870,7 @@ int wiringPiSetupSunxi (void)
     }
 
 
-    if (piModel == PI_MODEL_BANANAPIM4BERRY || piModel == PI_MODEL_BANANAPIM4ZERO) {
+    if (piModel == PI_MODEL_BANANAPIM4BERRY || piModel == PI_MODEL_BANANAPIM4ZERO || piModel == PI_MODEL_BANANAPIM4ZERO_V2) {
         sunxi_gpio = (uint32_t *)mmap(0, BLOCK_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, SUNXI_GPIO_BASE);
         if (sunxi_gpio == MAP_FAILED)
             return wiringPiFailure(WPI_ALMOST, "wiringPiSetupSunxi: mmap (GPIO) failed: %s\n", strerror(errno));
@@ -905,7 +905,8 @@ void pinModeSunxi (int pin, int mode)
     if (mode == INPUT)
     {
         if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO ||
+            piModel == PI_MODEL_BANANAPIM4ZERO_V2) {
             *(sunxi_gpio + mmap_seek) &= ~(7 << offset);
         }
         else
@@ -914,7 +915,8 @@ void pinModeSunxi (int pin, int mode)
     else if (mode == OUTPUT)
     {
         if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO ||
+            piModel == PI_MODEL_BANANAPIM4ZERO_V2) {
             *(sunxi_gpio + mmap_seek) &= ~(7 << offset);
             *(sunxi_gpio + mmap_seek) |=  (1 << offset);
         }
@@ -958,7 +960,8 @@ void pullUpDnControlSunxi (int pin, int pud)
     }
 
     if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO ||
+            piModel == PI_MODEL_BANANAPIM4ZERO_V2) {
         *(sunxi_gpio + mmap_seek) &= ~(3 << offset);
         *(sunxi_gpio + mmap_seek) |= (bit_value & 3) << offset;
     }
@@ -981,7 +984,8 @@ int digitalReadSunxi (int pin)
     mmap_seek = phyaddr >> 2;
 
     if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO ||
+            piModel == PI_MODEL_BANANAPIM4ZERO_V2) {
         if (*(sunxi_gpio + mmap_seek) & (1 << index))
             retval = HIGH;
         else
@@ -1009,7 +1013,8 @@ void digitalWriteSunxi (int pin, int value)
 
 
     if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO ||
+            piModel == PI_MODEL_BANANAPIM4ZERO_V2) {
         if (value == LOW)
             *(sunxi_gpio + mmap_seek) &= ~(1 << index);
         else
@@ -1060,7 +1065,8 @@ int pinGetModeSunxi (int pin)
     mmap_seek = phyaddr >> 2;
 
     if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO ||
+            piModel == PI_MODEL_BANANAPIM4ZERO_V2) {
             retval = (*(sunxi_gpio + mmap_seek) >> offset) & 7;
     }
     else
@@ -1083,8 +1089,18 @@ void setInfoSunxi(char *hardware, void *vinfo)
        info->manufacturer = "Bananapi";
        info->processor = "AW SUN50IW9";
    }
+   else if (strstr(hardware, "BananaPi BPI-M4-Zero v2"))
+   {
+       piModel = PI_MODEL_BANANAPIM4ZERO_V2;
+       info->type = "BPI-M4Zero V2";
+       info->p1_revision = 3;
+       info->ram = "2048M/4096M";
+       info->manufacturer = "Bananapi";
+       info->processor = "AW SUN50IW9";
+   }
    else if (strstr(hardware, "BPI-M4Zero") ||
-       strstr(hardware, "BananaPi M4 Zero"))
+	    strstr(hardware, "BananaPi BPI-M4-Zero") ||
+	    strstr(hardware, "BananaPi M4 Zero"))
    {
        piModel = PI_MODEL_BANANAPIM4ZERO;
        info->type = "BPI-M4Zero";
@@ -1094,7 +1110,7 @@ void setInfoSunxi(char *hardware, void *vinfo)
        info->processor = "AW SUN50IW9";
    }
    else
-       wiringPiFailure(WPI_FATAL, "setInfoSunxi: This code should only be called for Bananapi\n");
+     wiringPiFailure(WPI_FATAL, "setInfoSunxi: This code should only be called for Bananapi (not %s)\n", hardware);
    
     return;
 }
@@ -1110,6 +1126,11 @@ void setMappingPtrsSunxi(void)
     {
         pin_to_gpio = (const int(*)[41]) & physToGpioBananapiM4Zero;
         bcm_to_sunxigpio = &bcmToOGpioBananapiM4Zero;
+    }
+    else if (piModel == PI_MODEL_BANANAPIM4ZERO_V2)
+    {
+        pin_to_gpio = (const int(*)[41]) & physToGpioBananapiM4ZeroV2;
+        bcm_to_sunxigpio = &bcmToOGpioBananapiM4ZeroV2;
     }
 }
 #endif /* end SUNXI_SUPPORT */

--- a/source/bananapi.h
+++ b/source/bananapi.h
@@ -19,7 +19,8 @@
 #define	PI_MODEL_BANANAPICM5BPICM4IO	11
 #define	PI_MODEL_BANANAPIM4BERRY	12
 #define	PI_MODEL_BANANAPIM4ZERO		13
-#define	PI_MODEL_BANANAPIF3		14
+#define	PI_MODEL_BANANAPIM4ZERO_V2	14
+#define	PI_MODEL_BANANAPIF3		15
 
 #define AML_SUPPORT
 #define SUNXI_SUPPORT
@@ -758,7 +759,71 @@ static const int physToGpioBananapiM4Berry[64] = {
 	-1, -1, -1, -1, -1, -1, -1	// 57...63
 };
 
-static const int pinToGpioBananapiM4Zero[64] = {
+static const int pinToGpioBananapiM4Zero[64] = {   // for original boards with realtek wifi
+	// wiringPi number to native gpio number
+	226,   192+11,	//  0 |  1 : PH2, PG11/PI1
+	227,   192+2,	//  2 |  3 : PH3, PG2/PI11
+	192+8,   192+9,	//  4 |  5 : PG8/PI15, PG9/PI16
+	192+1, 192+19,	//  6 |  7 : PG1/PC2, PG19/PI12(PWM2)
+	192+16, 192+15,	//  8 |  9 : PG16/PI6(I2C0_SDA), PG15/PI5(I2C0_SCL)
+	229,    233,	// 10 | 11 : PH5(SPI1_SS), PH9
+	231,    232,	// 12 | 13 : PH7(SPI1_MOSI), PH8(SPI1_MISO)
+	230,    192+6,	// 14 | 15 : PH6(SPI1_CLK), PG6/PI13(UART4_TX)
+	192+7  -1,	// 16 | 17 : PG7/PI14(UART4_RX),
+	 -1,   -1,	// 18 | 19 :
+	 -1, 192+3,	// 20 | 21 : , PG3/PI10
+	192+4, 192+5,	// 22 | 23 : PG4/PI9, PG5/PH10
+	192+12, 192+10,	// 24 | 25 : PG12/PI2, PG10/PI0
+	192+0, 224+4,	// 26 | 27 : PG0/PH4, PH4/PC7
+	192+14, 192+13,	// 28 | 29 : PG14/PI4, PG13/PI3
+	192+18, 192+17,	// 30 | 31 : PG18/PI8(I2C1_SDA), PG17/PI7(I2C1_SCL)
+	// Padding:
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,	// 32...47
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,	// 48...63
+};
+
+const int bcmToOGpioBananapiM4Zero[64] = {       	      // BCM ModE
+     -1,  -1, 192+16, 192+15, 192+19, 192+3, 192+4, 233,      // 0..7
+     229, 232, 231, 230, 228, 192+5, 192+6, 192+7         ,      // 8..15
+    224+4, 226, 192+11, 192+12, 192+14, 192+13, 192+2, 192+8, // 16..23
+    192+9, 192+1, 192+19, 227,  -1,  -1,  -1,  -1, // 24..31
+// Padding:
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1, // 32..39
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1, // 40..47
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1, // 48..55
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1  // 56..63
+};
+
+static const int physToGpioBananapiM4Zero[64] = {
+	// physical header pin number to native gpio number
+	 -1,		//  0
+	 -1,   -1,	//  1 |  2 : 3.3V, 5.0V
+	192+16,   -1,	//  3 |  4 : PG16(I2C4_SDA), 5.0V
+	192+15,   -1,	//  5 |  6 : PG15(I2C4_SCL), GND
+	192+19, 192+6,	//  7 |  8 : PG19, PG6(UART1_TX)
+	 -1,    192+7,	//  9 | 10 : GND(PWM1), PG7(UAR1_RX)
+	226,    192+11,	// 11 | 12 : PH2, PG11
+	227,   -1,	// 13 | 14 : PH3, GND
+	192+2,  192+8,	// 15 | 16 : PG2, PG8
+	 -1,    192+9,	// 17 | 18 : 3.3V, PG9
+	231,   -1,	// 19 | 20 : PH7(SPI1_MOSI), GND
+	232,    192+1,	// 21 | 22 : PH8(SPI1_MISO), PG1
+	230,    229,	// 23 | 24 : PH6(SPI1_CLK), PH5(SPI1_SS)
+	 -1,    233,	// 25 | 26 : GND, PH9
+	192+18, 192+17,	// 27 | 28 : PG18(I2C3_SDA), PG17(I2C3_SCL)
+        192+3,  -1,	// 29 | 30 : PG3, GND
+	192+4,  192+0,	// 31 | 32 : PG4, PG0
+	192+5,  -1,	// 33 | 34 : PG5, GND
+	192+12, 224+4,	// 35 | 36 : PG12, PH4
+	192+10, 192+14,	// 37 | 38 : PG10, PG14
+	 -1,    192+13,	// 39 | 40 : GND, PG13
+	// Not used
+	-1, -1, -1, -1, -1, -1, -1, -1,	// 41...48
+	-1, -1, -1, -1, -1, -1, -1, -1,	// 49...56
+	-1, -1, -1, -1, -1, -1, -1	// 57...63
+};
+
+static const int pinToGpioBananapiM4ZeroV2[64] = { // bananapi m4zero V2 with broadcom wifi
 	// wiringPi number to native gpio number
 	226, 257,	//  0 |  1 : PH2, PI1
 	227, 267,	//  2 |  3 : PH3, PI11
@@ -771,7 +836,7 @@ static const int pinToGpioBananapiM4Zero[64] = {
 	270,  -1,	// 16 | 17 : PI14(UART4_RX),
 	 -1,  -1,	// 18 | 19 :
 	 -1, 266,	// 20 | 21 : , PI10
-	265, 234,	// 22 | 23 : PI9, PH10
+	265, 234,	// 22 | 23 : PI9, PG5/PH10
 	258, 256,	// 24 | 25 : PI2, PI0
 	228,  71,	// 26 | 27 : PH4, PC7
 	260, 259,	// 28 | 29 : PI4, PI3
@@ -781,8 +846,8 @@ static const int pinToGpioBananapiM4Zero[64] = {
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,	// 48...63
 };
 
-const int bcmToOGpioBananapiM4Zero[64] = {	// BCM ModE
-     -1,  -1, 262, 261, 268, 266, 265, 233, // 0..7
+const int bcmToOGpioBananapiM4ZeroV2[64] = {	// BCM ModE
+     -1,  -1, 262, 261, 192+19, 192+6, 192+4, 233, // 0..7
     229, 232, 231, 230, 228, 234, 269, 270, // 8..15
     71, 226, 257, 258, 260, 259, 267, 271, // 16..23
     272, 66, 256, 227,  -1,  -1,  -1,  -1, // 24..31
@@ -793,34 +858,35 @@ const int bcmToOGpioBananapiM4Zero[64] = {	// BCM ModE
      -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1  // 56..63
 };
 
-static const int physToGpioBananapiM4Zero[64] = {
+static const int physToGpioBananapiM4ZeroV2[64] = {
 	// physical header pin number to native gpio number
 	 -1,		//  0
 	 -1,  -1,	//  1 |  2 : 3.3V, 5.0V
-	262,  -1,	//  3 |  4 : PG16(I2C4_SDA), 5.0V
-	261,  -1,	//  5 |  6 : PG15(I2C4_SCL), GND
-	268, 269,	//  7 |  8 : PG19, PG6(UART1_TX)
-	 -1, 270,	//  9 | 10 : GND(PWM1), PG7(UAR1_RX)
-	226, 257,	// 11 | 12 : PH2, PG11
+	262,  -1,	//  3 |  4 : PG16/PI6(I2C4_SDA), 5.0V
+	261,  -1,	//  5 |  6 : PG15/PI5(I2C4_SCL), GND
+	268, 269,	//  7 |  8 : PG19/PI12, PG6/PI13(UART1_TX)
+	 -1, 270,	//  9 | 10 : GND(PWM1), PG7/PI14(UAR1_RX)
+	226, 257,	// 11 | 12 : PH2, PG11/PI1
 	227,  -1,	// 13 | 14 : PH3, GND
-	267, 271,	// 15 | 16 : PG2, PG8
-	 -1, 272,	// 17 | 18 : 3.3V, PG9
+	267, 271,	// 15 | 16 : PG2/PH11, PG8/PI15
+	 -1, 272,	// 17 | 18 : 3.3V, PG9/PI16
 	231,  -1,	// 19 | 20 : PH7(SPI1_MOSI), GND
-	232,  66,	// 21 | 22 : PH8(SPI1_MISO), PG1
+	232,  66,	// 21 | 22 : PH8(SPI1_MISO), PG1/PC2
 	230, 229,	// 23 | 24 : PH6(SPI1_CLK), PH5(SPI1_SS)
 	 -1, 233,	// 25 | 26 : GND, PH9
-	264, 263,	// 27 | 28 : PG18(I2C3_SDA), PG17(I2C3_SCL)
-	266,  -1,	// 29 | 30 : PG3, GND
-	265, 228,	// 31 | 32 : PG4, PG0
-	234,  -1,	// 33 | 34 : PG5, GND
-	258,  71,	// 35 | 36 : PG12, PH4
-	256, 260,	// 37 | 38 : PG19, PG14
-	 -1, 259,	// 39 | 40 : GND, PG13
+	264, 263,	// 27 | 28 : PG18/PI8(I2C3_SDA), PG17/PI7(I2C3_SCL)
+	266,  -1,	// 29 | 30 : PG3/PI10, GND
+	265, 228,	// 31 | 32 : PG4/PI9, PG0/PH4
+	234,  -1,	// 33 | 34 : PG5/PH10, GND
+	258,  71,	// 35 | 36 : PG12/PI2, PH4/PC7
+	256, 260,	// 37 | 38 : PG10/PI0, PG14/PI4
+	 -1, 259,	// 39 | 40 : GND, PG13/PI3
 	// Not used
 	-1, -1, -1, -1, -1, -1, -1, -1,	// 41...48
 	-1, -1, -1, -1, -1, -1, -1, -1,	// 49...56
 	-1, -1, -1, -1, -1, -1, -1	// 57...63
 };
+
 #endif /* end SUNXI_SUPPORT */
 
 /* =======================================================================================
@@ -994,6 +1060,8 @@ extern const int physToGpioBananapiM4Berry[64];
 extern const int bcmToOGpioBananapiM4Berry[64];
 extern const int physToGpioBananapiM4Zero[64];
 extern const int bcmToOGpioBananapiM4Zero[64];
+extern const int physToGpioBananapiM4ZeroV2[64];
+extern const int bcmToOGpioBananapiM4ZeroV2[64];
 
 int wiringPiSetupSunxi (void);
 void wiringPiCleanupSunxi (void);

--- a/source/cpuinfo.c
+++ b/source/cpuinfo.c
@@ -56,8 +56,10 @@ int get_rpi_info(rpi_info *info)
       }
 #endif
 #ifdef SUNXI_SUPPORT
+      printf("Looking for banana: %s\n", hardware);
       if (strstr(hardware, "BananaPi M4 Berry") ||
-          strstr(hardware, "BananaPi M4 Zero"))  {
+          strstr(hardware, "BananaPi BPI-M4-Zero")  ||
+          strstr(hardware, "BananaPi BPI-M4-Zero v2"))  {
           sunxi_found = found = 1;
       }
 #endif

--- a/source/cpuinfo.c
+++ b/source/cpuinfo.c
@@ -37,7 +37,7 @@ int get_rpi_info(rpi_info *info)
    FILE *fp;
    char buffer[1024];
    char hardware[1024];
-   char revision[1024];
+   char revision[1024] = "";
    int found = 0;
    int len;
 


### PR DESCRIPTION
There are 2 versions of the Bananapi m4zero.  The original has a Realtek wifi chipset. The new "V2" ones have Broadcom wifi.  Internally a lot of the GPIO pins connect to different pins on the chips. I forked your version of RPi.GPIO to make it work on both versions of the board.

The original board matches the old labels in the comments in the pin mapping sections.  The new board has a lot of PI** instead of PG**, and a few other differences.

The changes have been tested with Waveshare E-paper, Pimoroni Display Hat Mini, a PiSugar 3 power supply I2C data on pins (physical) 3 & 5 i2c4-pg (on Original M4Zero.  I do not have that interface working yet on the V2 boards), and a UART GPS on pins 8&10 RX/TX.