### PR TITLE
Added support for the older version of M4 Zero with the Realtek wireless chipset and different GPIO layout

### DIFF
--- a/source/bananapi.h
+++ b/source/bananapi.h
@@ -25,6 +25,7 @@
 #define	PI_MODEL_BANANAPIF5                                      15
 #define	PI_MODEL_BANANAPIAI2N                                 16
 #define	PI_MODEL_BANANAPIAI2H                                 17
+#define	PI_MODEL_BANANAPIM4ZERO_V1                           18
 
 #define AML_SUPPORT
 #define SUN50IW9_SUPPORT

--- a/source/bpi_sunxi.c
+++ b/source/bpi_sunxi.c
@@ -47,7 +47,7 @@ int wiringPiSetupSun50iw9 (void)
     }
 
 
-    if (piModel == PI_MODEL_BANANAPIM4BERRY || piModel == PI_MODEL_BANANAPIM4ZERO) {
+    if (piModel == PI_MODEL_BANANAPIM4BERRY || piModel == PI_MODEL_BANANAPIM4ZERO || piModel == PI_MODEL_BANANAPIM4ZERO_V1) {
         sun50iw9_gpio = (uint32_t *)mmap(0, BLOCK_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, SUN50IW9_GPIO_BASE);
         if (sun50iw9_gpio == MAP_FAILED)
             return wiringPiFailure(WPI_ALMOST, "wiringPiSetupSun50iw9: mmap (GPIO) failed: %s\n", strerror(errno));
@@ -82,7 +82,7 @@ void pinModeSun50iw9 (int pin, int mode)
     if (mode == INPUT)
     {
         if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO || piModel == PI_MODEL_BANANAPIM4ZERO_V1) {
             *(sun50iw9_gpio + mmap_seek) &= ~(7 << offset);
         }
         else
@@ -91,7 +91,7 @@ void pinModeSun50iw9 (int pin, int mode)
     else if (mode == OUTPUT)
     {
         if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO || piModel == PI_MODEL_BANANAPIM4ZERO_V1) {
             *(sun50iw9_gpio + mmap_seek) &= ~(7 << offset);
             *(sun50iw9_gpio + mmap_seek) |=  (1 << offset);
         }
@@ -135,7 +135,7 @@ void pullUpDnControlSun50iw9 (int pin, int pud)
     }
 
     if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO || piModel == PI_MODEL_BANANAPIM4ZERO_V1) {
         *(sun50iw9_gpio + mmap_seek) &= ~(3 << offset);
         *(sun50iw9_gpio + mmap_seek) |= (bit_value & 3) << offset;
     }
@@ -158,7 +158,7 @@ int digitalReadSun50iw9 (int pin)
     mmap_seek = phyaddr >> 2;
 
     if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO || piModel == PI_MODEL_BANANAPIM4ZERO_V1) {
         if (*(sun50iw9_gpio + mmap_seek) & (1 << index))
             retval = HIGH;
         else
@@ -186,7 +186,7 @@ void digitalWriteSun50iw9 (int pin, int value)
 
 
     if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO || piModel == PI_MODEL_BANANAPIM4ZERO_V1) {
         if (value == LOW)
             *(sun50iw9_gpio + mmap_seek) &= ~(1 << index);
         else
@@ -237,7 +237,7 @@ int pinGetModeSun50iw9 (int pin)
     mmap_seek = phyaddr >> 2;
 
     if (piModel == PI_MODEL_BANANAPIM4BERRY||
-            piModel == PI_MODEL_BANANAPIM4ZERO) {
+            piModel == PI_MODEL_BANANAPIM4ZERO || piModel == PI_MODEL_BANANAPIM4ZERO_V1) {
             retval = (*(sun50iw9_gpio + mmap_seek) >> offset) & 7;
     }
     else
@@ -261,10 +261,20 @@ void setInfoSun50iw9(char *hardware, void *vinfo)
        info->processor = "AW SUN50IW9";
    }
    else if (strstr(hardware, "BPI-M4Zero") ||
-       strstr(hardware, "BananaPi M4 Zero"))
+       strstr(hardware, "BananaPi M4 Zero") ||
+       strstr(hardware, "BananaPi BPI-M4-Zero v2"))
    {
        piModel = PI_MODEL_BANANAPIM4ZERO;
        info->type = "BPI-M4Zero";
+       info->p1_revision = 3;
+       info->ram = "2048M/4096M";
+       info->manufacturer = "Bananapi";
+       info->processor = "AW SUN50IW9";
+   }
+   else if (strstr(hardware, "BananaPi BPI-M4-Zero"))
+   {
+       piModel = PI_MODEL_BANANAPIM4ZERO_V1;
+       info->type = "BPI-M4Zero V1";
        info->p1_revision = 3;
        info->ram = "2048M/4096M";
        info->manufacturer = "Bananapi";
@@ -287,6 +297,11 @@ void setMappingPtrsSun50iw9(void)
     {
         pin_to_gpio = (const int(*)[41]) & physToGpioBananapiM4Zero;
         bcm_to_sun50iw9gpio = &bcmToOGpioBananapiM4Zero;
+    }
+    else if (piModel == PI_MODEL_BANANAPIM4ZERO_V1)
+    {
+        pin_to_gpio = (const int(*)[41]) & physToGpioBananapiM4ZeroV1;
+        bcm_to_sun50iw9gpio = &bcmToOGpioBananapiM4ZeroV1;
     }
 }
 #endif /* end SUN50IW9_SUPPORT */

--- a/source/bpi_sunxi.h
+++ b/source/bpi_sunxi.h
@@ -156,6 +156,71 @@ static const int physToGpioBananapiM4Zero[64] = {
 	-1, -1, -1, -1, -1, -1, -1	// 57...63
 };
 
+// BananaPi M4 Zero V1 (original board with Realtek WiFi, DT model "BananaPi BPI-M4-Zero")
+static const int pinToGpioBananapiM4ZeroV1[64] = {
+	// wiringPi number to native gpio number
+	226, 203,	//  0 |  1 : PH2, PG11
+	227, 194,	//  2 |  3 : PH3, PG2
+	200, 201,	//  4 |  5 : PG8, PG9
+	193, 211,	//  6 |  7 : PG1, PG19
+	208, 207,	//  8 |  9 : PG16, PG15
+	229, 233,	// 10 | 11 : PH5(SPI1_SS), PH9
+	231, 232,	// 12 | 13 : PH7(SPI1_MOSI), PH8(SPI1_MISO)
+	230, 198,	// 14 | 15 : PH6(SPI1_CLK), PG6
+	199,  -1,	// 16 | 17 : PG7,
+	 -1,  -1,	// 18 | 19 :
+	 -1, 195,	// 20 | 21 : , PG3
+	196, 197,	// 22 | 23 : PG4, PG5
+	204, 202,	// 24 | 25 : PG12, PG10
+	192, 228,	// 26 | 27 : PG0, PH4
+	206, 205,	// 28 | 29 : PG14, PG13
+	210, 209,	// 30 | 31 : PG18, PG17
+	// Padding:
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,	// 32...47
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,	// 48...63
+};
+
+const int bcmToOGpioBananapiM4ZeroV1[64] = {	// BCM Mode
+     -1,  -1, 208, 207, 211, 195, 196, 233,	// 0..7
+    229, 232, 231, 230, 228, 197, 198, 199,	// 8..15
+    228, 226, 203, 204, 206, 205, 194, 200,	// 16..23
+    201, 193, 211, 227,  -1,  -1,  -1,  -1,	// 24..31
+// Padding:
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,	// 32..39
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,	// 40..47
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,	// 48..55
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1	// 56..63
+};
+
+static const int physToGpioBananapiM4ZeroV1[64] = {
+	// physical header pin number to native gpio number
+	 -1,		//  0
+	 -1,  -1,	//  1 |  2 : 3.3V, 5.0V
+	208,  -1,	//  3 |  4 : PG16(I2C4_SDA), 5.0V
+	207,  -1,	//  5 |  6 : PG15(I2C4_SCL), GND
+	211, 198,	//  7 |  8 : PG19, PG6(UART1_TX)
+	 -1, 199,	//  9 | 10 : GND, PG7(UART1_RX)
+	226, 203,	// 11 | 12 : PH2, PG11
+	227,  -1,	// 13 | 14 : PH3, GND
+	194, 200,	// 15 | 16 : PG2, PG8
+	 -1, 201,	// 17 | 18 : 3.3V, PG9
+	231,  -1,	// 19 | 20 : PH7(SPI1_MOSI), GND
+	232, 193,	// 21 | 22 : PH8(SPI1_MISO), PG1
+	230, 229,	// 23 | 24 : PH6(SPI1_CLK), PH5(SPI1_SS)
+	 -1, 233,	// 25 | 26 : GND, PH9
+	210, 209,	// 27 | 28 : PG18(I2C3_SDA), PG17(I2C3_SCL)
+	195,  -1,	// 29 | 30 : PG3, GND
+	196, 192,	// 31 | 32 : PG4, PG0
+	197,  -1,	// 33 | 34 : PG5, GND
+	204, 228,	// 35 | 36 : PG12, PH4
+	202, 206,	// 37 | 38 : PG10, PG14
+	 -1, 205,	// 39 | 40 : GND, PG13
+	// Not used
+	-1, -1, -1, -1, -1, -1, -1, -1,	// 41...48
+	-1, -1, -1, -1, -1, -1, -1, -1,	// 49...56
+	-1, -1, -1, -1, -1, -1, -1	// 57...63
+};
+
 #endif /* SUN50IW9_SUPPORT */
 
 /* =======================================================================================
@@ -265,6 +330,8 @@ extern const int physToGpioBananapiM4Berry[64];
 extern const int bcmToOGpioBananapiM4Berry[64];
 extern const int physToGpioBananapiM4Zero[64];
 extern const int bcmToOGpioBananapiM4Zero[64];
+extern const int physToGpioBananapiM4ZeroV1[64];
+extern const int bcmToOGpioBananapiM4ZeroV1[64];
 
 int wiringPiSetupSun50iw9 (void);
 void wiringPiCleanupSun50iw9 (void);

--- a/source/cpuinfo.c
+++ b/source/cpuinfo.c
@@ -61,7 +61,8 @@ int get_rpi_info(rpi_info *info)
 #endif
 #ifdef SUN50IW9_SUPPORT
       if (strstr(hardware, "BananaPi M4 Berry") ||
-          strstr(hardware, "BananaPi M4 Zero"))  {
+          strstr(hardware, "BananaPi M4 Zero") ||
+          strstr(hardware, "BananaPi BPI-M4-Zero"))  {
           sun50iw9_found = found = 1;
       }
 #endif


### PR DESCRIPTION
It adds the GPIO pinouts and declarations for the old board as PI_MODEL_BANANAPIM4ZERO_V1 leaving the current version of the board as PI_MODEL_BANANAPIM4ZERO
